### PR TITLE
dev: added more stuff to the interpreter

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gydo.js",
-  "version": "2.0.0-dev.7648641a28415686211b5362af7113227cf9c58d",
+  "version": "2.0.0-dev.53b518be7ecea84fdd2c37a1cb800f71d963dc93",
   "description": "'Gydo-js' is a form of discord.js designed to simplify the process of creating a Discord bot.",
   "files": [
     "src",

--- a/src/bot/BaseBot.js
+++ b/src/bot/BaseBot.js
@@ -12,7 +12,7 @@ const { Client } = require('discord.js');
  */
 
 /**
- * Base Class of the Class Bot, all events goes here
+ * Base Class of/for the Bot Class, all events goes here
  */
 class BaseBot {
     constructor(client) {
@@ -78,6 +78,8 @@ class BaseBot {
      * @param {ClientError} callback
      */
     onError(callback) {
+        if (typeof callback !== 'function') throw new Error('First Argument is not a function.');
+        
         this.client.on('error', (err) => callback(err));
     }
     
@@ -92,6 +94,8 @@ class BaseBot {
      * @param {BotReady} cb
      */
     onReady(cb) {
+        if (typeof cb !== 'function') throw new Error('First Argument is not a function.');
+        
         this.client.on('ready', (c) => cb(c));
     }
     

--- a/src/bot/interpreter.js
+++ b/src/bot/interpreter.js
@@ -3,20 +3,17 @@
 const { MessageEmbed, Client } = require("discord.js");
 const fs = require('fs');
 const path = require('path');
-const { commands } = require('../Collections');
+const { embeds } = require('../Collections');
 const InterpreterError = require('../utils/InterpreterError');
 
 /** 
- * Message Event Interpreter 
+ * Message Event Interpreter
+ * Specifically for gydo.js
  * Detects the messages and see if
  * it matches the command you made
  */
 class interpreter {
-    /**
-     * Interpreter
-     * @param {Client} client - The Current Client that's running
-     */
-    constructor(client) {
+    constructor(client, collections) {
         if(!client instanceof Client || !client) throw new Error('Client Parameter has no value');
                 
         client.on('messageCreate', async (message) => {
@@ -26,19 +23,19 @@ class interpreter {
             const args = message.content.slice(prefix.length).trim().split(/ +/);
             const command = args.shift().toLowerCase();
             
-            const cmdProperties = commands.get(command);
             if(!message.content.startsWith(prefix)) return;
             if(message.author.bot) return;
             
-            const cmdName = cmdProperties?.name;
-            const code = `${cmdProperties ? cmdProperties?.code : ''}`
-            const messageReply = cmdProperties?.messageReply;
-            const sendTyping = cmdProperties?.sendTyping;
+            const {
+                cmdName,
+                code,
+                messageReply,
+                sendTyping,
+            } = await this.getAllProperties(collections, command);
 
             this.code = code;
             this._author = message.author;
             this.args = args;
-        
         
             this._message = message;
             this.currentCommand = cmdName;
@@ -46,7 +43,7 @@ class interpreter {
             this.res = code;
             
             // Start the Interpreter
-            await this._startInterpreter(client, message.author, args, message, cmdName);
+            await this.startInterpreter(client, message.author, args, message, cmdName);
             let res = await this.res;
             const isReply = messageReply ? true : false;
             let EmbedResult = await this._getEmbed(client, command);
@@ -87,63 +84,82 @@ class interpreter {
         });
     }
     
+    /**
+     * Gets all Properties of the command(s) user has created
+     * @param {Collection} collections - Collections of Commands and Embeds
+     * @param {string} currentCommand - The current command being requested
+     * @returns {Object}
+     */
+    async getAllProperties(collections, currentCommand) {
+        const [commands] = collections;
+        const cmdProperties = await commands.get(currentCommand);
+        const cmdName = cmdProperties?.name;
+        const code = `${cmdProperties ? cmdProperties?.code : ''}`
+        const messageReply = cmdProperties?.messageReply;
+        const sendTyping = cmdProperties?.sendTyping;
+        
+        return {
+            cmdName,
+            code,
+            messageReply,
+            sendTyping,
+        }
+    }
+    
     /** 
      * Gets the Embed of the command, if there is one
-     * @param {Client} client The Client you are running
-     * @param {string} command The name of the command
+     * @param {Client} client - The Client you are running
+     * @param {string} command - The name of the command
      * @returns {MessageEmbed[]|null}
      * @private
      */
     _getEmbed(client, command) {
+        if((embeds.get(command)) === null) return null;
+        
         // Raw Embed Values
-        const RawEmbedTitle = client.embedTitle.get(command);
-        const RawEmbedDescription = client.embedDesc.get(command);
-        const RawEmbedFooter = client.embedFooter.get(command);
-        const RawEmbedFields = client.embedFields.get(command);
-        const RawEmbedColor = client.embedColor.get(command);
-        const RawEmbedTimestamp = client.embedTimestamp.get(command);
-        const RawEmbedAuthor = client.embedAuthor.get(command);
-        const RawEmbedAuthorURL = client.embedAuthorURL.get(command);
+        const RawEmbed = embeds.get(command);
             
         let EmbedRaw = new MessageEmbed();
-            
+        
+        // Converts it all to an Embed
         if (
-            RawEmbedTitle !== undefined && 
-            RawEmbedDescription !== undefined
+            RawEmbed?.title !== undefined && 
+            RawEmbed?.description !== undefined
         ) {
-            if (RawEmbedTitle) EmbedRaw.setTitle(RawEmbedTitle.toString());
+            if (RawEmbed?.title) EmbedRaw.setTitle(RawEmbed?.title?.toString());
             
-            if (RawEmbedDescription) EmbedRaw.setDescription(RawEmbedDescription.toString());
+            if (RawEmbed?.description) EmbedRaw.setDescription(RawEmbed?.description?.toString());
             
-            if (RawEmbedFooter) EmbedRaw.setFooter(RawEmbedFooter.toString());
+            if (RawEmbed?.footer) EmbedRaw.setFooter(RawEmbed?.footer?.toString());
             
-            if (RawEmbedFields) {
-                const EmbedFields = RawEmbedFields.forEach((x) => {
-                    EmbedRaw.addField(x.name, x.value, x.inline ? x.inline : null);
+            if (RawEmbed?.fields) {
+                const EmbedFields = RawEmbed?.fields?.forEach((x) => {
+                    EmbedRaw.addField(x.name, x.value, x.inline ? x.inline : false);
                 });
             }
             
-            if (RawEmbedColor) EmbedRaw.setColor(RawEmbedColor.toString());
+            if (RawEmbed?.color) EmbedRaw.setColor(RawEmbed?.color?.toString());
             
-            if (RawEmbedTimestamp && RawEmbedTimestamp == true) EmbedRaw.setTimestamp();
+            if (RawEmbed?.timestamp && RawEmbed?.timestamp === true) EmbedRaw.setTimestamp();
             
-            if (RawEmbedAuthor) {
-                const AuthorURL = RawEmbedAuthorURL ? RawEmbedAuthorURL.toString() : null;
+            if (RawEmbed?.author) {
+                const AuthorURL = RawEmbed?.authorURL ? RawEmbed?.authorURL.toString() : null;
                 
-                EmbedRaw.setAuthor(RawEmbedAuthor.toString(), AuthorURL);
+                EmbedRaw.setAuthor(RawEmbed?.author?.toString(), AuthorURL);
             }
             
             return [EmbedRaw];
-        } else return [];
+        } 
+        
+        return [];
     }
     
     /**
      * Starts the Interpreter
      * @param {Client} client
      * @returns {string}
-     * @private
      */
-    async _startInterpreter(client, author, args, message, currentCommand) {
+    async startInterpreter(client, author, args, message, currentCommand) {
         const funcs = fs.readdirSync(path.join(__dirname, "../funcs")).filter(file => file.endsWith('.js'));
         
         /**

--- a/src/bot/main.js
+++ b/src/bot/main.js
@@ -7,7 +7,7 @@ const client = require('../utils/client');
 const fs = require("fs");
 const chalk = require("chalk");
 
-const { commands } = require('../Collections');
+const { commands, embeds } = require('../Collections');
 client.botprefix = new Collection();
 
 const Interpreter = require("./interpreter");
@@ -160,7 +160,10 @@ class Bot extends BaseBot {
      * Listens/Detects for Message Creation, and Detects the command, if any.
      */
     MessageDetect() {
-        new Interpreter(client);
+        new Interpreter(client, [
+            commands,
+            embeds
+        ]);
     }
 }
 

--- a/src/managers/Embed.js
+++ b/src/managers/Embed.js
@@ -1,22 +1,16 @@
+'use strict';
+
 const client = require('../utils/client');
 const { MessageEmbed, Collection } = require('discord.js');
 const discord = require('discord.js');
-
-client.embedTitle = new Collection();
-client.embedDesc = new Collection();
-client.embedFooter = new Collection();
-client.embedFields = new Collection();
-client.embedColor = new Collection();
-client.embedTimestamp = new Collection();
-client.embedAuthor = new Collection();
-client.embedAuthorURL = new Collection();
+const { embeds } = require('../Collections');
 
 /**
  * Discord Message Embed
  */
 class Embed {
     /** 
-     * @typedef {Object} IEmbed
+     * @typedef {Object} EmbedStructure
      * @property {string} [title]
      * @property {string} [author]
      * @property {string} [authorURL]
@@ -27,8 +21,8 @@ class Embed {
      * @property {boolean} [timestamp]
      */
     
-    /** 
-     * @typedef {Object[]} IEmbedFields
+    /**
+     * @typedef {Object[]} EmbedFields
      * @property {string} [name]
      * @property {string} [value]
      * @property {boolean} [inline]
@@ -45,24 +39,17 @@ class Embed {
 
         const { title, description, footer, fields, color, timestamp, author, authorURL } = options;
         
-        this.target = target;
-        this.embedTitle = title;
-        this.embedDesc = description;
-        this.embedFooter = footer;
-        this.embedFields = fields;
-        this.embedColor = color;
-        this.embedTimestamp = timestamp;
-        this.embedAuthor = author;
-        this.embedAuthorURL = authorURL;
+        this.target = target ?? null;
+        this.title = title ?? null;
+        this.description = description ?? null;
+        this.footer = footer ?? null;
+        this.fields = fields ?? null;
+        this.color = color ?? null;
+        this.timestamp = timestamp ?? null;
+        this.author = author ?? null;
+        this.authorURL = authorURL ?? null;
         
-        client.embedTitle.set(target, title);
-        client.embedDesc.set(target, description);
-        client.embedFooter.set(target, footer);
-        client.embedFields.set(target, fields);
-        client.embedColor.set(target, color);
-        client.embedTimestamp.set(target, timestamp);
-        client.embedAuthor.set(target, author);
-        client.embedAuthorURL.set(target, authorURL);
+        embeds.set(target, { ...this });
     }
     
     /** 
@@ -70,8 +57,8 @@ class Embed {
      * @returns {MessageEmbed}
      */
     static JSONtoEmbed(rawjson) {
-        const JSONparse = JSON.parse(rawjson);
-        const Embed = new MessageEmbed(JSONparse);
+        const parsed = JSON.parse(rawjson);
+        const Embed = new MessageEmbed(parsed);
         
         return Embed;
     }
@@ -82,14 +69,16 @@ class Embed {
      */
     toJSON() {
         return {
-            title: this.embedTitle,
-            description: this.embedDesc,
-            footer: this.embedFooter,
-            fields: this.embedFields,
-            color: this.embedColor,
-            timestamp: this.embedTimestamp,
-            author: this.embedAuthor,
-            authorURL: this.embedAuthorURL
+            title: this.title,
+            description: this.description,
+            footer: this.footer,
+            fields: this.fields,
+            color: this.color,
+            timestamp: this.timestamp,
+            author: {
+                name: this.author,
+                url: this.authorURL,
+            },
         }
     }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,5 +7,5 @@
         "module": "commonjs",
         "skipDefaultLibCheck": true
     }, 
-    "exclude": ["node_modules", "package-lock.json", "src", "docs"]
+    "exclude": ["node_modules", "src", "docs"]
 }

--- a/typings/index.d.ts
+++ b/typings/index.d.ts
@@ -9,14 +9,15 @@ import {
     Constants,
     CommandInteractionOptionResolver,
     ColorResolvable,
+    Collection,
+    GuildMember,
     HexColorString,
     Intents,
     Message,
+    MessageEmbed,
     Presence,
     User,
-    GuildMember,
     Role,
-    MessageEmbed,
     Interaction
 } from "discord.js";
 import { EventEmitter } from 'events';
@@ -24,7 +25,7 @@ import {
     Snowflake,
 } from 'discord-api-types/v9';
 
-//#region
+//#region Classes
 export class ActivityManager {
     public constructor(data: Bot);
     public setActivity(status: string, options: ActivityTypes): void;
@@ -83,21 +84,21 @@ export interface SupportedClientEvents {
 
 export class EventsManager extends EventEmitter {
     public constructor();
-    public on<I extends keyof SupportedClientEvents>(event: I, listener: (...args: SupportedClientEvents[I]) => Awaitable<void>): this;
+    public on<K extends keyof SupportedClientEvents>(event: K, listener: (...args: SupportedClientEvents[K]) => Awaitable<void>): this;
     
-    public on<O extends string | symbol>(
-        event: Exclude<O, keyof SupportedClientEvents>, listener: (...args: any[]) => Awaitable<void>
+    public on<S extends string | symbol>(
+        event: Exclude<S, keyof SupportedClientEvents>, listener: (...args: any[]) => Awaitable<void>
     ): this;
     
-    public emit<I extends keyof SupportedClientEvents>(event: I, ...args: SupportedClientEvents[I]): boolean;
-    public emit<E extends string | symbol>(
-        event: Exclude<E, keyof SupportedClientEvents>, ...args: unknown[]
+    public emit<K extends keyof SupportedClientEvents>(event: K, ...args: SupportedClientEvents[K]): boolean;
+    public emit<S extends string | symbol>(
+        event: Exclude<S, keyof SupportedClientEvents>, ...args: unknown[]
     ): boolean;
     
-    public off<I extends keyof SupportedClientEvents>(event: I, listener: (...args: SupportedClientEvents[I]) => Awaitable<void>): this;
+    public off<K extends keyof SupportedClientEvents>(event: K, listener: (...args: SupportedClientEvents[K]) => Awaitable<void>): this;
     
-    public off<O extends string | symbol>(
-        event: Exclude<O, keyof SupportedClientEvents>, listener: (...args: any[]) => Awaitable<void>
+    public off<S extends string | symbol>(
+        event: Exclude<S, keyof SupportedClientEvents>, listener: (...args: any[]) => Awaitable<void>
     ): this;
 }
 
@@ -114,7 +115,8 @@ export class guildMemberRemove {
 }
 
 export class interpreter {
-    public constructor(client: Client);
+    public constructor(client: Client, collections: Collection[]);
+    public getAllProperties(collections: Collection[], currentCommand: string): Promise<object>;
     private _getEmbed(client: Client, command: string): MessageEmbed | null;
     private _isReply(command: string, client: Client): boolean;
     private readonly code: string;
@@ -123,7 +125,7 @@ export class interpreter {
     private readonly args: string[];
     private readonly _message: string;
     private readonly currentCommand: string | null;
-    private _startInterpreter(client: Client): string;
+    public  startInterpreter(client: Client): Promise<void>;
 }
 
 export class InterpreterError extends Error {
@@ -168,7 +170,7 @@ export class SlashCommandManager {
 
 //#endregion
 
-//#region
+//#region Interfaces and Types
 export interface BotOptions {
     token: string;
     prefix: string;


### PR DESCRIPTION
# Changes
- **Embed:** now only uses one collection for storing an embed
- **Interpreter:** 1. `startInterpreter()` is no longer private. 
2. Added `getAllProperties()` method to get all command(s) properties a user has created, and to minimize the constructor. 
3. Constructor now has `collections` parameter for all of the Collections of Commands and Embeds