### PR TITLE
fix contribution link on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ bot.command({
 
 You can contribute on gydo.js dev branch by making a pull request on our [GitHub Repository](https://github.com/Gydo-Team/gydo.js)
 
-[See Contributing Guide](https://github.com/Gydo-Team/gydo.js-dev/blob/main/docs/CONTRIBUTING.md)
+[See Contributing Guide](https://github.com/Gydo-Team/gydo.js/blob/main/CONTRIBUTING.md)
 
 ...and Thanks for Contributing!
 


### PR DESCRIPTION
***Fixed contribution link on README file, cuz it redirects you to `gydo.js-dev` (which is archived)***